### PR TITLE
Regenerate `Cargo.lock` via `cargo vendor` for `0.2.9`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "KIT-ILIAS-downloader"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "futures-util",


### PR DESCRIPTION
First of all, thanks a lot for this incredibly useful tool! :heart: 

While updating to `0.2.9` I realized that the build would fail since `Cargo.lock` wasn't regenerated
for `0.2.9` (even though it's just a one-line change, the update of the version field to be precise).

While this is not a big deal for people building Rust code in a traditional manner with a simple
`cargo install`, I actually got bitten by this since I build most of my packages using a rather exotic
package-manager named Nix[1] which runs build-processes in a fully isolated environment
(and uses the `--frozen` flag in `cargo` builds for even less side-effects during builds).

The fix was obviously quite easy, applying the patch in my build-expression for Nix was sufficient, I just
figured that after taking care of it, filing the change against upstream would make sense as well ;-)

[1] https://nixos.org/