### PR TITLE
pass login: Only use first line from result

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -201,8 +201,8 @@ pub fn ask_user_pass(opt: &Opt) -> Result<(String, String)> {
 			))?
 		} else {
 			pass = String::from_utf8(pw_out.stdout).map(|x| {
-				x.trim_end().to_string()
-			}).expect("utf-8 decode of `pass(1)`-output failed");
+				x.lines().next().map(|x| x.to_owned()).ok_or_else(|| anyhow!("empty pass(1) entry!"))
+			})?.expect("utf-8 decode of `pass(1)`-output failed");
 			should_store = false;
 		}
 	} else {


### PR DESCRIPTION
It's possible to create multi-line entries in `pass(1)` where additional
lines have further metadata, e.g.

    $ pass show kit-access
    <secret pw>
    user: uXXXX

which can be helpful to persist e.g. the corresponding username.

However it's a convention that the password is only in the first line,
e.g. `pass show -c` (which is used by `passmenu` to copy a secret into
the clipboard) only the first line is used by default.

I switched to such an approach recently and realized that this is now a
problem because `KIT-ILIAS-Downloader` passes the entire string to the
SAML login, so I decided to just strip everything after the first line
in the output of `pass show`.

We may want to implement support for extracting usernames from such a
format in the future, but... that's an exercise left for the reader ;-)